### PR TITLE
Implement random rotation to ASE integrators

### DIFF
--- a/src/flashmd/ase/bussi.py
+++ b/src/flashmd/ase/bussi.py
@@ -17,9 +17,10 @@ class Bussi(VelocityVerlet):
         time_constant: float = 10.0 * ase.units.fs,
         device: str | torch.device = "auto",
         rescale_energy: bool = True,
+        random_rotation: bool = False,
         **kwargs,
     ):
-        super().__init__(atoms, timestep, model, device, rescale_energy, **kwargs)
+        super().__init__(atoms, timestep, model, device, rescale_energy, random_rotation, **kwargs)
 
         self.temperature_K = temperature_K
         self.time_constant = time_constant

--- a/src/flashmd/ase/langevin.py
+++ b/src/flashmd/ase/langevin.py
@@ -19,9 +19,10 @@ class Langevin(VelocityVerlet):
         time_constant: float = 100.0 * ase.units.fs,
         device: str | torch.device = "auto",
         rescale_energy: bool = True,
+        random_rotation: bool = False,
         **kwargs,
     ):
-        super().__init__(atoms, timestep, model, device, rescale_energy, **kwargs)
+        super().__init__(atoms, timestep, model, device, rescale_energy, random_rotation, **kwargs)
 
         self.temperature_K = temperature_K
         self.friction = 1.0 / time_constant

--- a/src/flashmd/ase/velocity_verlet.py
+++ b/src/flashmd/ase/velocity_verlet.py
@@ -67,6 +67,7 @@ class VelocityVerlet(MolecularDynamics):
                 dtype=system.positions.dtype,
             )
             # apply the random rotation
+            old_cell = system.cell
             system.cell = system.cell @ R.T
             system.positions = system.positions @ R.T
             momenta = system.get_data("momenta").block(0).values.squeeze()
@@ -75,8 +76,8 @@ class VelocityVerlet(MolecularDynamics):
         new_system = self.stepper.step(system)
 
         if self.random_rotation:
-            # revert q, p, and cell to the original reference frame
-            new_system.cell = system.cell @ R
+            # revert q, p to the original reference frame, load old cell
+            new_system.cell = old_cell
             new_system.positions = system.positions @ R
             new_momenta = new_system.get_data("momenta").block(0).values.squeeze()
             new_momenta[:] = new_momenta @ R


### PR DESCRIPTION
As stated in title. Uses `Rotation` from `scipy.spatial.transform`. Function tested to work fine.

Note that I have tried to prevent error build-up in the cell by saving old cell and then just feeding that to the new system.