### PR TITLE
Implement `todict` for `EnergyCalculator`

### DIFF
--- a/src/flashmd/ase/__init__.py
+++ b/src/flashmd/ase/__init__.py
@@ -1,6 +1,3 @@
-import tempfile
-
-from metatomic.torch import AtomisticModel
 from metatomic.torch.ase_calculator import MetatomicCalculator
 
 
@@ -8,19 +5,9 @@ class EnergyCalculator(MetatomicCalculator):
     """
     ASE calculator for energy predictions using a metatomic AtomisticModel.
 
-    Slightly modified to save the model to a temporary file to ensure compatibility
-    with ase.io.Trajectory.
+    Slightly modified to ensure compatibility with ase.io.Trajectory, otherwise
+    completely equivalent to `metatomic.torch.ase_calculator.MetatomicCalculator`.
     """
 
-    def __init__(self, model, *args, **kwargs):
-        # save the model to a path otherwise it won't work with ase.io.Trajectory
-        # which calls todict on the calculator
-
-        if isinstance(model, AtomisticModel):
-            with tempfile.NamedTemporaryFile(delete=False, suffix=".pt") as f:
-                path = f.name
-            model.save(path)
-        else:
-            path = model
-
-        super().__init__(path, *args, **kwargs)
+    def todict(self):
+        return {"name": "flashmd.ase.EnergyCalculator"}


### PR DESCRIPTION
As in the title. Replaces the old workaround