### PR TITLE
Reduce Hugging Face downloads in the test suite

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+import functools
+
+import pytest
+
+import flashmd.models
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _cache_hf_downloads():
+    """Memoise Hugging Face downloads for the whole test session.
+
+    Several tests call ``get_pretrained``, which re-downloads the shared MLIP
+    checkpoint on every call. That burst of requests gets rate-limited (and
+    rejected) by the Hub in CI. Caching ``hf_hub_download`` by its arguments
+    means each file is fetched at most once per session.
+    """
+    original = flashmd.models.hf_hub_download
+    flashmd.models.hf_hub_download = functools.cache(original)
+    yield
+    flashmd.models.hf_hub_download = original

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -15,7 +15,7 @@ def test_isolated_atom(monkeypatch, tmp_path):
     atoms = ase.Atoms("O", positions=[[0, 0, 0]])
     thermalize_momenta(atoms, temperature_K=300)
 
-    time_step = 8
+    time_step = 64
     device = "cuda" if torch.cuda.is_available() else "cpu"
     energy_model, flashmd_model = get_pretrained("pet-omatpes-v2", time_step)
     calculator = EnergyCalculator(energy_model, device=device)
@@ -40,7 +40,7 @@ def test_slab_plus_isolated_atom(monkeypatch, tmp_path):
     atoms = slab + isolated_atom
     thermalize_momenta(atoms, temperature_K=300)
 
-    time_step = 8
+    time_step = 64
     device = "cuda" if torch.cuda.is_available() else "cpu"
     energy_model, flashmd_model = get_pretrained("pet-omatpes-v2", time_step)
     calculator = EnergyCalculator(energy_model, device=device)


### PR DESCRIPTION
## Problem

The test suite fetches model checkpoints from the Hugging Face Hub via `get_pretrained`. Across a full run this issues **14** `hf_hub_download` calls, and because every download is pinned to `revision="main"` each one hits the Hub even when the file is already cached. That burst gets rate-limited and rejected in CI, failing the tests on `main`.

## Changes

- **`tests/conftest.py`** — a session-scoped, autouse fixture memoises `flashmd.models.hf_hub_download` for the duration of the test session, so each `(repo_id, filename, revision)` is fetched at most once. Caching at the `hf_hub_download` boundary (rather than at `get_pretrained`) also dedupes the shared MLIP checkpoint that `get_pretrained` otherwise re-requests for every time step, and covers the README test whose model load happens inside `exec`. No existing test needed to change.
- **`tests/test_edge_cases.py`** — switch the two edge-case smoke tests from `time_step=8` to `64`, matching every other omat-v2 test. These tests only check that a short MD run completes, so the time step merely selects the checkpoint; sharing the 64 fs model drops a separate download.

## Effect

Distinct Hugging Face downloads per run: **14 → 7**.

The omat-v2 side is fully consolidated to one MLIP + one FlashMD checkpoint shared across the energy, edge-case, and README tests. The symplectic tests are left as-is: `test_symplectic_timestep_mismatch` structurally needs two different time steps, so those five files are already minimal.

## Notes / follow-ups

This only reduces in-session redundancy — a cold CI runner still downloads the 7 distinct files once each, and each is still a `revision="main"` request. If rate-limiting persists, the more robust fixes are pinning `revision` to an immutable commit SHA (lets a warm cache short-circuit without a network round-trip) and/or providing an `HF_TOKEN` in CI. Both touch `src`/CI config and are out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)